### PR TITLE
Remove extraneous text from Galois theory book recommendation

### DIFF
--- a/_books/galois-theory.md
+++ b/_books/galois-theory.md
@@ -11,4 +11,3 @@ Morandi, P. (1st Ed. 1996, GTM reprint 2011). *ISBN 9781461284758*.\\
 
 Complete treatment of field and Galois theory with some things that might not be covered in a standard abstract algebra book: the last chapter covers transcendental extensions as they arise for example in algebraic geometry.
 Contains a good collection of exercises.
-You do not have permission to send messages in this channel.


### PR DESCRIPTION
Get rid of "You do not have permission to send messages in this channel." which is a clear error in copying over from the Discord server channel.